### PR TITLE
Improve fetch vocab card algo.

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { getServerSession } from 'next-auth';
 import NotFound from './not-found';
 import SessionProvider from '@/app/components/session/SessionProvider'; // adjusted path
 import { routing } from '@/i18n/route';
+import LangCode from '@/types/languages';
 
 export const metadata = {
   title: 'Create Next App',
@@ -16,7 +17,7 @@ export const metadata = {
 
 interface RootLayoutProps {
   children: ReactNode;
-  params: { locale: string };
+  params: { locale: LangCode };
 }
 
 const RootLayout = async ({

--- a/src/app/[locale]/vocabulary/page.tsx
+++ b/src/app/[locale]/vocabulary/page.tsx
@@ -65,7 +65,7 @@ const Vocabulary: React.FC = () => {
     ): Promise<void> => {
       setIsLoading(true);
       setIsError(false);
-
+  
       try {
         const lexicalCategoryParameter = lexicalCategory
           ? `?wordType=${lexicalCategory}`

--- a/src/app/api/vocab-cards/route.ts
+++ b/src/app/api/vocab-cards/route.ts
@@ -13,6 +13,19 @@ interface filterType {
   nextReviewedAt?: Date;
 }
 
+const getUserCards = (
+  spacedRepetitionCards: VocabCardDocument[],  newCards: VocabCardDocument[],
+  spacedRepetitionLimit: number = 4, totalLimit: number = 9,
+): VocabCardDocument[] => {
+  // Fetches upto the Spaced Repetition Limit on corresponding cards with 
+  // remainder being un-attempted cards.
+  const spacedRepetitionCardCount = spacedRepetitionCards.length;
+  spacedRepetitionLimit = (spacedRepetitionCardCount < spacedRepetitionLimit)? spacedRepetitionCardCount:  spacedRepetitionLimit; 
+  const spacedRepetitionList = spacedRepetitionCards.slice(0, spacedRepetitionLimit);
+  const NewList = newCards.slice(0, totalLimit - spacedRepetitionLimit);
+  return [...spacedRepetitionList, ...NewList].sort(() => Math.random() - 0.5);
+}
+
 export const GET = async (request: NextRequest): Promise<NextResponse> => {
   try {
     const { searchParams } = new URL(request.url);
@@ -76,11 +89,9 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
         },
       });
 
-      const reviewableVocabCards = [
-        ...spacedRepetitionVocabCards,
-        ...notAttemptedVocabCards,
-      ];
-      return new NextResponse(JSON.stringify(reviewableVocabCards), {
+      const userVocabCards = getUserCards(spacedRepetitionVocabCards, notAttemptedVocabCards);
+      
+      return new NextResponse(JSON.stringify(userVocabCards), {
         status: 200,
       });
     }


### PR DESCRIPTION
- Updated algorithm for logged in user in fetch vocab-cards api to get upto the limit of spaced repetition cards (user may have 0). The remainder will be cards yet to be attempted. 
- The order is randomised so that upon board language being switched the answers cannot be identified.